### PR TITLE
Empty and zero-length strokes don't count as mistakes

### DIFF
--- a/lib/strokeOrderAnimationController.dart
+++ b/lib/strokeOrderAnimationController.dart
@@ -382,16 +382,15 @@ class StrokeOrderAnimationController extends ChangeNotifier {
   void checkStroke(List<Offset> rawPoints) {
     bool strokeIsCorrect = false;
 
-    if (currentStroke < nStrokes) {
-      List<Offset> points = getNonNullPointsFrom(rawPoints);
+    List<Offset> points = getNonNullPointsFrom(rawPoints);
+    final strokePath = convertOffsetsToPath(points);
+    final strokeLength = getPathLength(strokePath);
 
+    if (currentStroke < nStrokes && strokeLength > 0) {
       final currentMedian = medians[currentStroke];
 
       final medianPath = convertOffsetsToPath(currentMedian);
       final medianLength = getPathLength(medianPath);
-
-      final strokePath = convertOffsetsToPath(points);
-      final strokeLength = getPathLength(strokePath);
 
       // The x and y coordinates of the start and end point of the stroke have
       // to be within the margin around the start and end points of the median

--- a/test/strokeOrderAnimationController_test.dart
+++ b/test/strokeOrderAnimationController_test.dart
@@ -158,6 +158,18 @@ void main() {
         controller.startQuiz();
         expect(controller.summary.nTotalMistakes, 0);
       });
+
+      test('Empty stroke does not count as mistake', () {
+        controller.reset();
+        controller.checkStroke([]);
+        expect(controller.summary.nTotalMistakes, 0);
+      });
+
+      test('Stroke of length 0 does not count as mistake', () {
+        controller.reset();
+        controller.checkStroke([Offset(0, 0), Offset(0, 0)]);
+        expect(controller.summary.nTotalMistakes, 0);
+      });
     });
 
     group('Callbacks', () {


### PR DESCRIPTION
Prevents tapping somewhere during a quiz to be counted as a mistake.

Resolves #10 